### PR TITLE
Add Genre data to fixtures file, comment out instructions on home page

### DIFF
--- a/revenue/revenueapp/fixtures/review_data.json
+++ b/revenue/revenueapp/fixtures/review_data.json
@@ -1,5 +1,26 @@
 [
     {
+        "model":"revenueapp.genre",
+        "pk": 1,
+        "fields":{
+            "name":"Rock"
+        }
+    },
+    {
+        "model":"revenueapp.genre",
+        "pk": 2,
+        "fields":{
+            "name":"Pop"
+        }
+    },
+    {
+        "model":"revenueapp.genre",
+        "pk": 3,
+        "fields":{
+            "name":"Jazz"
+        }
+    },
+    {
         "model": "revenueapp.venue", 
         "pk": 1, 
         "fields": {
@@ -16,7 +37,7 @@
         "model": "revenueapp.venue", 
         "pk": 2, 
         "fields": {
-            "name": "One World Theathre", 
+            "name": "One World Theatre", 
             "address": "7701 Bee Caves Rd", 
             "city": "Austin", 
             "state": "TX", 

--- a/revenue/revenueapp/templates/home.html
+++ b/revenue/revenueapp/templates/home.html
@@ -30,7 +30,9 @@
     <img src= "{% static "media/home_background_1.jpg" %}" alt="venue" width: "70%" class = "center">
 
 
-    <p style="color: #f2f2f2; border-bottom: 4px; border-bottom-style:solid; border-bottom-color:#2a52be; padding: 1em; width: 700px; display: block; text-align: center; margin-left: auto; margin-right: auto">Welcome to reVENUE!<br><br>Please select a venue from the list below to see a review or create your own.  Want to review a venue not on this list?  Simply click on Create a Venue on the link above.  Rock on!<br></p>
+    <p style="color: #f2f2f2; border-bottom: 4px; border-bottom-style:solid; border-bottom-color:#2a52be; padding: 1em; width: 700px; display: block; text-align: center; margin-left: auto; margin-right: auto">Welcome to reVENUE!<br>
+        {% comment %}<br>Please select a venue from the list below to see a review or create your own.  Want to review a venue not on this list?  Simply click on Create a Venue on the link above.  Rock on!<br>{% endcomment %}
+    </p>
     <div class="listbar">    
     <ul>
         {% for venue in venues %}

--- a/revenue/revenueapp/views.py
+++ b/revenue/revenueapp/views.py
@@ -10,9 +10,11 @@ from revenueapp.forms import ReviewUpdateForm
 
 class HomeView(View):
     def get(self, request):
+        # Retrieve venues that have a review
         venue_ids=Review.objects.values_list('venue',flat=True)
-        print(venue_ids)   
+        # print(venue_ids)
         venues = Venue.objects.filter(id__in=venue_ids)
+        
         context ={
             'venues' : venues
         }


### PR DESCRIPTION
Right now, if the user adds a venue using the create a venue form, they will not be able to see what they made displayed on the home page until they review it. This is not good because the instructions on the home page refer to a list of venues that doesn't exist. This PR removes the instructions text and adds Genre data to the fixtures file. 